### PR TITLE
Fix missing method - LibLynx\Connect\HTTPClient\SimpleCacheTokenPersistence

### DIFF
--- a/src/HTTPClient/SimpleCacheTokenPersistence.php
+++ b/src/HTTPClient/SimpleCacheTokenPersistence.php
@@ -44,4 +44,9 @@ class SimpleCacheTokenPersistence implements TokenPersistenceInterface
     {
         $this->cache->delete($this->cacheKey);
     }
+
+    public function hasToken()
+    {
+        $this->cache->has($this->cacheKey);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Running `composer test` currently produces the following error:

```bash
Fatal error: Class LibLynx\Connect\HTTPClient\SimpleCacheTokenPersistence contains 1 abstract 
method and must therefore be declared abstract or implement the remaining methods 
(kamermans\OAuth2\Persistence\TokenPersistenceInterface::hasToken) in 
/Users/dannylepage/www/liblynx-connect-php/src/HTTPClient/SimpleCacheTokenPersistence.php on line 9
```

Added remaining `hasToken()` abstract method in `LibLynx\Connect\HTTPClient\SimpleCacheTokenPersistence` to fix.

`composer test` now passes successfully.

![image](https://user-images.githubusercontent.com/1552482/46818442-2927a100-cd79-11e8-82bc-ac5cf7228d83.png)
